### PR TITLE
bump go to 1.22.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /go-change-delta
 unit-test-coverage.out
+.direnv

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -79,4 +79,4 @@ linters-settings:
       - name: atomic
 issues:
   exclude-dirs:
-    - examples
+    - .*/nix/store/.*

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
-golang 1.22.5
-golangci-lint 1.59.1
-typos 1.23.3
-shfmt 3.8.0
+golang 1.22.6
+golangci-lint 1.60.1
+typos 1.23.6
+shfmt 3.9.0
 shellcheck 0.10.0
 python 2.7.18
 pre-commit 2.7.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# WIP
-
 # go-change-delta
 
 go-change-delta is a tool to detect the blast radius of changes in a Go-based repository. It helps you identify which packages are affected by changes in your codebase, enabling more focused and efficient testing.
@@ -77,8 +75,3 @@ jobs:
 
 ## Contributing
 Contributions are welcome! Feel free to open an issue or submit a pull request.
-
-# TODO:
-
-- Setup and add CI
-- Add a github action to make using this easier in other CIs

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722062969,
-        "narHash": "sha256-QOS0ykELUmPbrrUGmegAUlpmUFznDQeR4q7rFhl8eQg=",
+        "lastModified": 1723991338,
+        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b73c2221a46c13557b1b3be9c2070cc42cf01eb3",
+        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
         "type": "github"
       },
       "original": {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require github.com/stretchr/testify v1.9.0
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/text v0.16.0
+	golang.org/x/text v0.17.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-golang.org/x/text v0.16.0 h1:a94ExnEXNtEwYLGJSIUxnWoxoRz/ZcCsV63ROupILh4=
-golang.org/x/text v0.16.0/go.mod h1:GhwF1Be+LQoKShO3cGOHzqOgRrGaYc9AvblQOmPVHnI=
+golang.org/x/text v0.17.0 h1:XtiM5bkSOt+ewxlOE/aE/AKEHibwj/6gvWMl9Rsh0Qc=
+golang.org/x/text v0.17.0/go.mod h1:BuEKDfySbSR4drPmRPG/7iBdf8hvFMuRexcpahXilzY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Currently blocked upgrading to go 1.23 by golangci-lint behaving differently in nix by checking ../../../../../../nix/store/.* files and none of the ways to ignore them currently work. Outside of nix everything works fine.