### PR TITLE
bump golang to 1.23.x, python to 3, and remove asdf .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,0 @@
-golang 1.22.6
-golangci-lint 1.60.1
-typos 1.23.6
-shfmt 3.9.0
-shellcheck 0.10.0
-python 2.7.18
-pre-commit 2.7.1

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723991338,
-        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
+        "lastModified": 1726937504,
+        "narHash": "sha256-bvGoiQBvponpZh8ClUcmJ6QnsNKw0EMrCQJARK3bI1c=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
+        "rev": "9357f4f23713673f310988025d9dc261c20e70c6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,22 +12,20 @@
         pkgs = import nixpkgs {
           inherit system;
           overlays = [ ];
-          config = {
-            permittedInsecurePackages = [
-              "python-2.7.18.8"
-            ];
-          };
         };
+
+        # set go version here that will be used in all shells
+        go = pkgs.go_1_23;
 
         scriptDir = toString ./.;  # Converts the flake's root directory to a string
 
         # Importing the shell environments from separate files
         fullEnv = pkgs.callPackage ./nix/devshell.nix {
-          inherit pkgs scriptDir;
+          inherit pkgs scriptDir go;
         };
 
         ciEnv = pkgs.callPackage ./nix/ci-runtests.nix {
-          inherit pkgs scriptDir;
+          inherit pkgs scriptDir go;
         };
       in rec {
         devShell = fullEnv;

--- a/nix/ci-runtests.nix
+++ b/nix/ci-runtests.nix
@@ -1,8 +1,5 @@
-{ pkgs, scriptDir }:
+{ pkgs, scriptDir, go }:
 with pkgs;
-let
-  go = pkgs.go_1_22;
-in
 mkShell {
   nativeBuildInputs = [
     bash

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,8 +1,5 @@
-{ pkgs, scriptDir }:
+{ pkgs, scriptDir, go }:
 with pkgs;
-let
-  go = pkgs.go_1_22;
-in
 mkShell {
   nativeBuildInputs = [
     # basics
@@ -25,7 +22,7 @@ mkShell {
     # linting tools
     typos
     pre-commit
-    python
+    python3
     shfmt
     shellcheck
   ];


### PR DESCRIPTION
- Moves go version declaration to flake.nix so it is in one place.
- Python3 pre-commit usage is now fixed so removing insecure package usage and moving to python3.
- Remove asdf environment now that nix environment is stable so we don't have to keep 2 environments 